### PR TITLE
Should FastFlow ask for Card URL?

### DIFF
--- a/spec/card.md
+++ b/spec/card.md
@@ -6,6 +6,7 @@ Database:
    * author name: String - used as an sTag, but also allows for by author search
    * citation: String- raw string from user generally MLA notation
    * notes: String- any user notes concerning the card or its use
+   * URL: String - allows FastFlow to grab all resources for offline use
 
 Functionality:
    * Create - create new cards from CardManager


### PR DESCRIPTION
URL as a separate field would allow the automation of downloading resources for offline use.

This functionality does not necessitate the URL as a separate field, we could REGEX the citation and find any links, and then download, but that would be less efficient.
