### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/FastFlowDebate/FastFlow.png?label=ready&title=Ready)](https://waffle.io/FastFlowDebate/FastFlow)
 # FastFlow
 [![Build Status](https://travis-ci.org/FastFlowDebate/FastFlow.svg?branch=master)](https://travis-ci.org/FastFlowDebate/FastFlow)
 [![Build status](https://ci.appveyor.com/api/projects/status/cg72fv9in3fe9gvk/branch/master?svg=true)](https://ci.appveyor.com/project/Zarkoix/fastflow/branch/master)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/FastFlowDebate/FastFlow

This was requested by a real person (user Zarkoix) on waffle.io, we're not trying to spam you.
